### PR TITLE
Lesson 4: Motion Magic profiles

### DIFF
--- a/src/main/java/first/robot/mechanisms/Arm.java
+++ b/src/main/java/first/robot/mechanisms/Arm.java
@@ -6,27 +6,22 @@ package first.robot.mechanisms;
 
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
-import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
 
 /**
  * The arm. One TalonFX motor plus a CANcoder that measures the arm's angle.
  *
- * <p>New in this lesson: closed-loop <b>position</b> control ({@link PositionVoltage}). Instead of
- * pushing a voltage and hoping, each command picks a target angle. The motor's PID controller
- * steers to that angle and holds it.
- *
- * <p>Also new: there is no stop command anymore. A {@code Mechanism} with nothing commanding it
- * runs an idle default command on its own, so we don't have to write one.
- *
- * <p>The next lesson (mech-4-MotionMagic) adds a motion profile on top of the same gains.
+ * <p>New in this lesson: <b>Motion Magic</b> position control ({@link MotionMagicVoltage}). Same
+ * gains as mech-3-PID, but instead of steering straight at the target, the motor follows a smooth speed
+ * ramp: speed up, cruise, slow down. The ramp is called a motion profile, and it keeps the arm from
+ * jerking.
  */
 public class Arm extends Mechanism {
   // Target positions (rotations, 1.0 = one full turn).
@@ -43,24 +38,32 @@ public class Arm extends Mechanism {
   private static final double kP = 0.0; // NEEDS TUNING, proportional gain
   private static final double kD = 0.0; // NEEDS TUNING, derivative gain
 
+  // Motion Magic speed limits: how fast the arm may move and how quickly it may speed up.
+  // TODO: set these before the arm moves under power. Good starting values:
+  // cruise=2 rot/s, accel=4 rot/s².
+  private static final double MOTION_MAGIC_CRUISE_VELOCITY = 0.0; // NEEDS SETTING, max rot/s
+  private static final double MOTION_MAGIC_ACCELERATION = 0.0; // NEEDS SETTING, max rot/s²
+
   private final CANBus canivore = new CANBus("canivore");
   private final TalonFX motor = new TalonFX(31, canivore);
   private final CANcoder encoder = new CANcoder(32, canivore);
 
-  // Asks the motor's PID to move the arm to a target angle and hold it.
-  private final PositionVoltage positionOut = new PositionVoltage(0);
+  // Moves the arm to a target angle along a smooth Motion Magic ramp.
+  private final MotionMagicVoltage positionOut = new MotionMagicVoltage(0);
 
   public Arm() {
     TalonFXConfiguration config = new TalonFXConfiguration();
     config.MotorOutput.NeutralMode = NeutralModeValue.Coast; // easy to move by hand
     config.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
     config.Slot0.GravityType = GravityTypeValue.Arm_Cosine; // fights gravity automatically
-    config.Slot0.StaticFeedforwardSign = StaticFeedforwardSignValue.UseClosedLoopSign;
 
     config.Slot0.kG = kG;
     config.Slot0.kS = kS;
     config.Slot0.kP = kP;
     config.Slot0.kD = kD;
+
+    config.MotionMagic.MotionMagicCruiseVelocity = MOTION_MAGIC_CRUISE_VELOCITY;
+    config.MotionMagic.MotionMagicAcceleration = MOTION_MAGIC_ACCELERATION;
 
     // Use the CANcoder for position, so PID works on the arm's real angle.
     config.Feedback.withRemoteCANcoder(encoder);

--- a/src/main/java/first/robot/mechanisms/Flywheel.java
+++ b/src/main/java/first/robot/mechanisms/Flywheel.java
@@ -9,7 +9,7 @@ import static org.wpilib.units.Units.RotationsPerSecond;
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.Follower;
-import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.MotorAlignmentValue;
@@ -21,9 +21,9 @@ import org.wpilib.command3.Mechanism;
  * The flywheel. Two TalonFX motors: a leader (CAN 21) and a follower (CAN 22) that spins the
  * opposite direction.
  *
- * <p>New in this lesson: closed-loop <b>velocity</b> control ({@link VelocityVoltage}). Each
- * command picks a speed in rotations per second, and the motor's PID holds that speed even when
- * game pieces slow the wheel down.
+ * <p>New in this lesson: <b>Motion Magic</b> velocity control ({@link MotionMagicVelocityVoltage}).
+ * Same gains as mech-3-PID, but the speed now ramps up to the target along an acceleration limit instead
+ * of jumping straight to it.
  */
 public class Flywheel extends Mechanism {
   // Shooting speeds (rotations per second).
@@ -35,12 +35,16 @@ public class Flywheel extends Mechanism {
   private static final double kV = 0.125; // volts per rotation-per-second
   private static final double kP = 0.0; // correction strength
 
+  // Motion Magic limits: how fast the wheel may spin and how quickly it may speed up.
+  private static final double MOTION_MAGIC_CRUISE_VELOCITY = 100.0; // top speed (rot/s)
+  private static final double MOTION_MAGIC_ACCELERATION = 1000.0; // ramp rate (rot/s²)
+
   private final CANBus canivore = new CANBus("canivore");
   private final TalonFX leader = new TalonFX(21, canivore);
   private final TalonFX follower = new TalonFX(22, canivore);
 
-  // Asks the motor's PID to hold a target speed.
-  private final VelocityVoltage velocityOut = new VelocityVoltage(0);
+  // Asks the motor to ramp to a target speed instead of jumping to it.
+  private final MotionMagicVelocityVoltage velocityOut = new MotionMagicVelocityVoltage(0);
 
   public Flywheel() {
     // The follower copies the leader, spinning the opposite direction.
@@ -52,6 +56,8 @@ public class Flywheel extends Mechanism {
     config.Slot0.kS = kS;
     config.Slot0.kV = kV;
     config.Slot0.kP = kP;
+    config.MotionMagic.MotionMagicCruiseVelocity = MOTION_MAGIC_CRUISE_VELOCITY;
+    config.MotionMagic.MotionMagicAcceleration = MOTION_MAGIC_ACCELERATION;
 
     leader.getConfigurator().apply(config);
   }


### PR DESCRIPTION
`MotionMagicVoltage` on the arm and `MotionMagicVelocityVoltage` on the flywheel, on the same Slot 0 gains. What is new is the ramp: the arm speeds up, cruises and slows down instead of lunging at the target. Cruise velocity and acceleration are the last two of the six numbers Workshop 1 produces.

Base is `mech-3-PID`, so this diff is exactly what this one lesson adds.

**Do not merge.** The seven `mech-*` branches are a teaching chain, each one lesson of change stacked on the last. Merging collapses the chain and breaks the lesson embeds on frc5712.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
