### PR TITLE
Lesson 5: let the mechanisms report where they are

### DIFF
--- a/src/main/java/first/robot/mechanisms/Arm.java
+++ b/src/main/java/first/robot/mechanisms/Arm.java
@@ -4,6 +4,8 @@
 
 package first.robot.mechanisms;
 
+import static org.wpilib.units.Units.Degrees;
+
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
@@ -14,19 +16,26 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
+import org.wpilib.units.measure.Angle;
 
 /**
  * The arm. One TalonFX motor plus a CANcoder that measures the arm's angle.
  *
- * <p>New in this lesson: <b>Motion Magic</b> position control ({@link MotionMagicVoltage}). Same
- * gains as mech-3-PID, but instead of steering straight at the target, the motor follows a smooth speed
- * ramp: speed up, cruise, slow down. The ramp is called a motion profile, and it keeps the arm from
- * jerking.
+ * <p>The motor uses Motion Magic position control ({@link MotionMagicVoltage}), added in
+ * mech-4-MotionMagic: it follows a smooth speed ramp to the target angle instead of jerking toward it.
+ *
+ * <p>New in this lesson (mech-5-ReadingState): the <b>read side</b>. {@link #getPosition} tells you
+ * where the arm is, {@link #getTargetPosition} tells you where it is headed, and {@link
+ * #isAtTarget} tells you whether it has arrived. That last check is how a hold gets an ending:
+ * {@code arm.vertical().until(arm::isAtTarget)} finishes when the arm is really there.
  */
 public class Arm extends Mechanism {
   // Target positions (rotations, 1.0 = one full turn).
   private static final double VERTICAL_POSITION = 0.25; // 90 degrees, stowed for transport
   private static final double HORIZONTAL_POSITION = 0.5; // 180 degrees, ground intake
+
+  // How close counts as "at target".
+  private static final double POSITION_TOLERANCE_DEGREES = 1.0;
 
   // PID + feedforward gains.
   // TODO: tune these on the real robot before the arm moves under power.
@@ -50,6 +59,8 @@ public class Arm extends Mechanism {
 
   // Moves the arm to a target angle along a smooth Motion Magic ramp.
   private final MotionMagicVoltage positionOut = new MotionMagicVoltage(0);
+
+  private final Angle tolerance = Degrees.of(POSITION_TOLERANCE_DEGREES);
 
   public Arm() {
     TalonFXConfiguration config = new TalonFXConfiguration();
@@ -78,7 +89,7 @@ public class Arm extends Mechanism {
   // wait for a hold. A hold inside Command.sequence sticks there forever. If a step needs an
   // ending, add one where you use the command instead of writing a new method here:
   //
-  //   arm.vertical().until(someCondition)   // ends when the condition turns true
+  //   arm.vertical().until(arm::isAtTarget)   // ends when the arm arrives
   //
   // Every hold has "(hold)" in its name. Names show up on the dashboard and in logs, so if a
   // stuck sequence is sitting on a "(hold)", you found the bug.
@@ -91,6 +102,21 @@ public class Arm extends Mechanism {
   /** Move to the horizontal (ground intake) position and hold it. Never finishes. */
   public Command horizontal() {
     return runRepeatedly(() -> setPosition(HORIZONTAL_POSITION)).named("horizontal (hold)");
+  }
+
+  /** True when the arm has reached its target angle. */
+  public boolean isAtTarget() {
+    return getPosition().isNear(getTargetPosition(), tolerance);
+  }
+
+  /** Current measured arm angle. */
+  public Angle getPosition() {
+    return encoder.getPosition().getValue();
+  }
+
+  /** Angle the arm is currently driving toward. */
+  public Angle getTargetPosition() {
+    return positionOut.getPositionMeasure();
   }
 
   private void setPosition(double rotations) {

--- a/src/main/java/first/robot/mechanisms/Flywheel.java
+++ b/src/main/java/first/robot/mechanisms/Flywheel.java
@@ -16,14 +16,18 @@ import com.ctre.phoenix6.signals.MotorAlignmentValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
+import org.wpilib.units.measure.AngularVelocity;
 
 /**
  * The flywheel. Two TalonFX motors: a leader (CAN 21) and a follower (CAN 22) that spins the
  * opposite direction.
  *
- * <p>New in this lesson: <b>Motion Magic</b> velocity control ({@link MotionMagicVelocityVoltage}).
- * Same gains as mech-3-PID, but the speed now ramps up to the target along an acceleration limit instead
- * of jumping straight to it.
+ * <p>The motor uses Motion Magic velocity control ({@link MotionMagicVelocityVoltage}), added in
+ * mech-4-MotionMagic: the speed ramps up to the target instead of jumping straight to it.
+ *
+ * <p>New in this lesson (mech-5-ReadingState): the <b>read side</b>. {@link #getVelocity} tells you
+ * how fast the wheel is really spinning, {@link #getTargetVelocity} tells you the speed it is
+ * aiming for, and {@link #isAtTarget} tells you whether it is up to speed.
  */
 public class Flywheel extends Mechanism {
   // Shooting speeds (rotations per second).
@@ -39,12 +43,17 @@ public class Flywheel extends Mechanism {
   private static final double MOTION_MAGIC_CRUISE_VELOCITY = 100.0; // top speed (rot/s)
   private static final double MOTION_MAGIC_ACCELERATION = 1000.0; // ramp rate (rot/s²)
 
+  // How close the measured speed needs to be to count as "at target".
+  private static final double VELOCITY_TOLERANCE_RPS = 0.5;
+
   private final CANBus canivore = new CANBus("canivore");
   private final TalonFX leader = new TalonFX(21, canivore);
   private final TalonFX follower = new TalonFX(22, canivore);
 
   // Asks the motor to ramp to a target speed instead of jumping to it.
   private final MotionMagicVelocityVoltage velocityOut = new MotionMagicVelocityVoltage(0);
+
+  private final AngularVelocity tolerance = RotationsPerSecond.of(VELOCITY_TOLERANCE_RPS);
 
   public Flywheel() {
     // The follower copies the leader, spinning the opposite direction.
@@ -64,8 +73,8 @@ public class Flywheel extends Mechanism {
 
   // Same setup as Arm. runRepeatedly runs the action every loop while the command is scheduled.
   // These commands are all holds. A hold never finishes, so never make a sequence wait on one.
-  // Need an ending? Add it where you use the command: flywheel.runFast().until(someCondition).
-  // The full rule is in Arm.java.
+  // Need an ending? Add it where you use the command:
+  // flywheel.runFast().until(flywheel::isAtTarget). The full rule is in Arm.java.
 
   /** Spin the flywheel at the slow speed and hold it. Never finishes. */
   public Command runSlow() {
@@ -80,6 +89,21 @@ public class Flywheel extends Mechanism {
   /** Stop the flywheel and keep it stopped. Never finishes. */
   public Command stop() {
     return runRepeatedly(leader::stopMotor).named("stop (hold)");
+  }
+
+  /** True when the flywheel is within tolerance of its target speed. */
+  public boolean isAtTarget() {
+    return getVelocity().isNear(getTargetVelocity(), tolerance);
+  }
+
+  /** Current measured flywheel speed. */
+  public AngularVelocity getVelocity() {
+    return leader.getVelocity().getValue();
+  }
+
+  /** Speed the flywheel is currently driving toward. */
+  public AngularVelocity getTargetVelocity() {
+    return velocityOut.getVelocityMeasure();
   }
 
   private void setVelocity(double rps) {

--- a/src/main/java/first/robot/opmode/TeleopOpMode.java
+++ b/src/main/java/first/robot/opmode/TeleopOpMode.java
@@ -7,6 +7,7 @@ package first.robot.opmode;
 import first.robot.Robot;
 import first.robot.mechanisms.Arm;
 import first.robot.mechanisms.Flywheel;
+import org.wpilib.command3.Command;
 import org.wpilib.command3.button.CommandNiDsXboxController;
 import org.wpilib.opmode.PeriodicOpMode;
 import org.wpilib.opmode.Teleop;
@@ -16,7 +17,8 @@ import org.wpilib.opmode.Teleop;
  * station. The button bindings made in the constructor belong to this OpMode, and the framework
  * removes them on a mode switch. No cleanup code needed.
  *
- * <p>The buttons here run the arm and flywheel PID commands.
+ * <p>The buttons here run the arm and flywheel PID commands. New in this lesson: the Y button
+ * builds a sequence that waits for the arm to really arrive before spinning up the flywheel.
  */
 @Teleop(name = "Teleop")
 public class TeleopOpMode extends PeriodicOpMode {
@@ -34,5 +36,25 @@ public class TeleopOpMode extends PeriodicOpMode {
 
     // A: spin fast while held, stop when released.
     driver.a().onTrue(flywheel.runFast()).onFalse(flywheel.stop());
+
+    // Y: raise the arm, wait until it really reaches the target, then spin the flywheel fast.
+    // Without isAtTarget there is no way to know when "then" is.
+    //
+    // vertical() is a hold, so it never finishes. Dropped straight into Command.sequence it would
+    // stick there forever. .until(arm::isAtTarget) gives the hold an ending right here. Do not
+    // add a special "AndWait" method to the mechanism. In an auto, also add .withTimeout(seconds)
+    // as a time limit. If the arm never quite arrives, the routine moves on instead of getting
+    // stuck for the rest of the period.
+    //
+    // The last step (runFast) is still a hold, so the whole sequence is a hold too. That is why
+    // its name ends in "(hold)" and why we use whileTrue: releasing Y cancels it.
+    driver
+        .y()
+        .whileTrue(
+            Command.sequence(
+                    arm.vertical().until(arm::isAtTarget).named("vertical until at target"),
+                    flywheel.runFast())
+                .named("Spin Up When Ready (hold)"))
+        .whileFalse(flywheel.stop());
   }
 }


### PR DESCRIPTION
The read side. `getPosition`, `getTargetPosition` and `isAtTarget` within a one degree tolerance. This is what gives a hold an ending: `arm.vertical().until(arm::isAtTarget)` finishes when the arm really arrives. Nothing downstream works without it.

Base is `mech-4-MotionMagic`, so this diff is exactly what this one lesson adds.

**Do not merge.** The seven `mech-*` branches are a teaching chain, each one lesson of change stacked on the last. Merging collapses the chain and breaks the lesson embeds on frc5712.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
