### PR TITLE
Lesson 4: let the mechanisms report where they are

### DIFF
--- a/src/main/java/first/robot/mechanisms/Arm.java
+++ b/src/main/java/first/robot/mechanisms/Arm.java
@@ -4,6 +4,7 @@
 
 package first.robot.mechanisms;
 
+import static org.wpilib.units.Units.Degrees;
 import static org.wpilib.units.Units.RotationsPerSecond;
 import static org.wpilib.units.Units.RotationsPerSecondPerSecond;
 import static org.wpilib.units.Units.Volts;
@@ -23,19 +24,18 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
+import org.wpilib.units.measure.Angle;
 
 /**
  * The arm. One TalonFX motor plus a CANcoder that measures the arm's angle.
  *
- * <p>New in this lesson: the arm goes closed loop. Instead of pushing a voltage and hoping, each
- * command names a target angle, and the motor drives to it along a <b>Motion Magic</b> profile
- * ({@link MotionMagicVoltage}) that speeds up, cruises and slows down so the arm does not jerk.
+ * <p>The motor uses Motion Magic position control ({@link MotionMagicVoltage}), added one lesson
+ * back. It follows a smooth speed ramp to the target angle instead of jerking at it.
  *
- * <p>The gains are not typed here. They are pasted out of Phoenix Tuner X, where you measured them
- * in Workshop 1.
- *
- * <p>There is also no stop command anymore. A {@code Mechanism} with nothing commanding it runs an
- * idle default command on its own.
+ * <p>New in this lesson (mech-4-ReadingState): the <b>read side</b>. {@link #getPosition} tells you
+ * where the arm is, {@link #getTargetPosition} tells you where it is headed, and {@link
+ * #isAtTarget} tells you whether it has arrived. That last check is how a hold gets an ending:
+ * {@code arm.vertical().until(arm::isAtTarget)} finishes when the arm is really there.
  */
 public class Arm extends Mechanism {
   private final CANBus canivore = new CANBus("canivore");
@@ -44,6 +44,9 @@ public class Arm extends Mechanism {
 
   // Moves the arm to a target angle along a smooth Motion Magic ramp.
   private final MotionMagicVoltage positionOut = new MotionMagicVoltage(0);
+
+  // How close counts as "at target".
+  private final Angle tolerance = Degrees.of(1.0);
 
   public Arm() {
     // Pasted from Tuner X. Every gain is 0.0 until you paste yours over it.
@@ -93,6 +96,21 @@ public class Arm extends Mechanism {
    */
   public Command horizontal() {
     return runRepeatedly(() -> setPosition(0.5)).named("horizontal (hold)");
+  }
+
+  /** True when the arm has reached its target angle. */
+  public boolean isAtTarget() {
+    return getPosition().isNear(getTargetPosition(), tolerance);
+  }
+
+  /** Current measured arm angle. */
+  public Angle getPosition() {
+    return encoder.getPosition().getValue();
+  }
+
+  /** Angle the arm is currently driving toward. */
+  public Angle getTargetPosition() {
+    return positionOut.getPositionMeasure();
   }
 
   private void setPosition(double rotations) {

--- a/src/main/java/first/robot/mechanisms/Flywheel.java
+++ b/src/main/java/first/robot/mechanisms/Flywheel.java
@@ -19,16 +19,18 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import org.wpilib.command3.Command;
 import org.wpilib.command3.Mechanism;
+import org.wpilib.units.measure.AngularVelocity;
 
 /**
  * The flywheel. One TalonFX motor (CAN 21). No CANcoder: the encoder inside the motor already
  * measures speed.
  *
- * <p>New in this lesson: the flywheel goes closed loop, with <b>Motion Magic</b> velocity control
- * ({@link MotionMagicVelocityVoltage}). A command names a speed in rotations per second and the
- * motor's PID holds it even as game pieces slow the wheel down.
+ * <p>The motor uses Motion Magic velocity control ({@link MotionMagicVelocityVoltage}), added one
+ * lesson back. The speed ramps up to the target instead of jumping straight to it.
  *
- * <p>Its gains come out of Tuner X the same way the arm's do.
+ * <p>New in this lesson (mech-4-ReadingState): the <b>read side</b>. {@link #getVelocity} tells you
+ * how fast the wheel is really spinning, {@link #getTargetVelocity} tells you the speed it is
+ * aiming for, and {@link #isAtTarget} tells you whether it is up to speed.
  */
 public class Flywheel extends Mechanism {
   private final CANBus canivore = new CANBus("canivore");
@@ -36,6 +38,9 @@ public class Flywheel extends Mechanism {
 
   // Asks the motor to ramp to a target speed instead of jumping to it.
   private final MotionMagicVelocityVoltage velocityOut = new MotionMagicVelocityVoltage(0);
+
+  // How close the measured speed needs to be to count as "at target".
+  private final AngularVelocity tolerance = RotationsPerSecond.of(0.5);
 
   public Flywheel() {
     // Pasted from Tuner X. Every gain is 0.0 until you paste yours over it.
@@ -75,6 +80,21 @@ public class Flywheel extends Mechanism {
   /** Stop the flywheel and keep it stopped. Never finishes. */
   public Command stop() {
     return runRepeatedly(this::stopMotor).named("stop (hold)");
+  }
+
+  /** True when the flywheel is within tolerance of its target speed. */
+  public boolean isAtTarget() {
+    return getVelocity().isNear(getTargetVelocity(), tolerance);
+  }
+
+  /** Current measured flywheel speed. */
+  public AngularVelocity getVelocity() {
+    return motor.getVelocity().getValue();
+  }
+
+  /** Speed the flywheel is currently driving toward. */
+  public AngularVelocity getTargetVelocity() {
+    return velocityOut.getVelocityMeasure();
   }
 
   private void setVelocity(double rps) {

--- a/src/main/java/first/robot/opmode/MyTeleop.java
+++ b/src/main/java/first/robot/opmode/MyTeleop.java
@@ -5,6 +5,7 @@
 package first.robot.opmode;
 
 import first.robot.Robot;
+import org.wpilib.command3.Command;
 import org.wpilib.command3.button.CommandNiDsXboxController;
 import org.wpilib.opmode.PeriodicOpMode;
 import org.wpilib.opmode.Teleop;
@@ -14,7 +15,8 @@ import org.wpilib.opmode.Teleop;
  * station. The button bindings made in the constructor belong to this OpMode, and the framework
  * removes them on a mode switch. No cleanup code needed.
  *
- * <p>The buttons here run the arm and flywheel PID commands.
+ * <p>The buttons here run the arm and flywheel PID commands. New in this lesson: the Y button
+ * builds a sequence that waits for the arm to really arrive before spinning up the flywheel.
  */
 @Teleop(name = "Teleop")
 public class MyTeleop extends PeriodicOpMode {
@@ -30,5 +32,28 @@ public class MyTeleop extends PeriodicOpMode {
 
     // A: spin fast while held, stop when released.
     driver.a().whileTrue(robot.flywheel.runFast()).whileFalse(robot.flywheel.stop());
+
+    // Y: raise the arm, wait until it really reaches the target, then spin the flywheel fast.
+    // Without isAtTarget there is no way to know when "then" is.
+    //
+    // vertical() is a hold, so it never finishes. Dropped straight into Command.sequence it would
+    // stick there forever. .until(arm::isAtTarget) gives the hold an ending right here. Do not
+    // add a special "AndWait" method to the mechanism. In an auto, also add .withTimeout(seconds)
+    // as a time limit. If the arm never quite arrives, the routine moves on instead of getting
+    // stuck for the rest of the period.
+    //
+    // The last step (runFast) is still a hold, so the whole sequence is a hold too. That is why
+    // its name ends in "(hold)" and why we use whileTrue: releasing Y cancels it.
+    driver
+        .y()
+        .whileTrue(
+            Command.sequence(
+                    robot.arm
+                        .vertical()
+                        .until(robot.arm::isAtTarget)
+                        .named("vertical until at target"),
+                    robot.flywheel.runFast())
+                .named("Spin Up When Ready (hold)"))
+        .whileFalse(robot.flywheel.stop());
   }
 }


### PR DESCRIPTION
The read side. getPosition for where the arm is, getTargetPosition for where it is headed, isAtTarget for whether it got there, within a one degree tolerance.\n\nThis is what gives a hold an ending: arm.vertical().until(arm::isAtTarget) finishes when the arm really arrives.

Base is `mech-3-MotionMagic`, so this diff is exactly what this one lesson adds.

**Do not merge.** The `mech-*` branches are a teaching chain, each one lesson of change stacked on the last. Merging collapses the chain and breaks the lesson embeds on frc5712.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
